### PR TITLE
Load direnv `.envrc` from `.zprofile` for non-interactive shells

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -73,6 +73,14 @@ if (( $+commands[nodenv] )); then
 fi
 
 #
+# direnv — load .envrc for non-interactive shells (agents)
+# Interactive shells still use `direnv hook` in .zshrc for cd/prompt reload.
+#
+if (( $+commands[direnv] )); then
+  eval "$(direnv export zsh 2>/dev/null)"
+fi
+
+#
 # Less
 #
 


### PR DESCRIPTION
Cursor agents skip `.zshrc` (and its `direnv` hook), so secrets in `~/.envrc` were missing unless callers used `direnv exec`. Export once at profile load alongside the existing `nodenv` PATH bootstrap to support non-interactive shells, particularly those from Agents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs `direnv export` for every login/profile load when direnv is installed, which can expose or override env vars in non-interactive contexts; stderr is suppressed on export failure.
> 
> **Overview**
> **Non-interactive shells** (e.g. agent subprocesses that load `.zprofile` but not `.zshrc`) now run `direnv export zsh` when `direnv` is on `PATH`, so `.envrc` variables are applied at login without `direnv exec`.
> 
> Interactive sessions are unchanged: `.zshrc` still uses `direnv hook zsh` for reload on `cd` and prompt updates. The new block sits next to the existing **nodenv** bootstrap in `runcoms/zprofile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948d270a96f9b30c707acfc653de6c14fb2e4fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->